### PR TITLE
Revert "Fix Travis depreciation" (skip_cleanup always required)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ deploy:
     file: bintray-descriptor.json
     user: axel3rd
     key: $BINTRAY_API_KEY
+    skip_cleanup: true
     on:
       jdk: oraclejdk11    
     # Tag deployment
@@ -32,6 +33,7 @@ deploy:
     file: bintray-descriptor.json
     user: axel3rd
     key: $BINTRAY_API_KEY
+    skip_cleanup: true
     on:
       tags: true
       jdk: oraclejdk11


### PR DESCRIPTION
This reverts commit 5899bcaa76ff8e1b6a6d26334294b669527df2ce.