### PR TITLE
add Ligue Super in ChampionishType nut not suported currently

### DIFF
--- a/src/main/java/org/blondin/mpg/Main.java
+++ b/src/main/java/org/blondin/mpg/Main.java
@@ -89,6 +89,10 @@ public class Main {
             LOG.info("\nSorry, Champions League is currently not supported.\n");
             return;
         }
+        if (league.getChampionship().equals(ChampionshipType.LIGUE_SUPER)) {
+            LOG.info("\nSorry, Ligue Super is currently not supported.\n");
+            return;
+        }
         switch (league.getStatus()) {
         case TERMINATED:
             // Already managed previously

--- a/src/main/java/org/blondin/mpg/root/model/ChampionshipType.java
+++ b/src/main/java/org/blondin/mpg/root/model/ChampionshipType.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum ChampionshipType {
 
-    LIGUE_1(1), PREMIER_LEAGUE(2), LIGA(3), LIGUE_2(4), SERIE_A(5), CHAMPIONS_LEAGUE(6);
+    LIGUE_1(1), PREMIER_LEAGUE(2), LIGA(3), LIGUE_2(4), SERIE_A(5), CHAMPIONS_LEAGUE(6), LIGUE_SUPER(7);
 
     private final int value;
 


### PR DESCRIPTION
There is a new league type in mpg
Ligue Super 

It's a combination of 4 league (French, Italian, Spain, England)

Maybe later. I will try to integrate this to the bot